### PR TITLE
apply permissions recursively

### DIFF
--- a/DEBIAN/postinst
+++ b/DEBIAN/postinst
@@ -10,5 +10,9 @@ chmod 755 /usr/bin/lite-upgrade-system-series3
 chmod 644 /usr/share/applications/liteupgrade.desktop
 chmod 644 /usr/share/pixmaps/update-manager.png
 
+# This folder MUST have correct permissions for systems with multiple accounts
+chown root:root /etc/skel -R
+find /etc/skel -type d -exec chmod 755 {} \;
+find /etc/skel -type f -exec chmod 644 {} \;
 [ -f "/etc/skel/.conky/start" ] && chmod +x /etc/skel/.conky/start
 [ -f "/etc/skel/.conky/updates" ] && chmod +x /etc/skel/.conky/updates


### PR DESCRIPTION
Apply permissions recursively to make sure /etc/skel has the proper
folders and files permissions.